### PR TITLE
Add KeyboardType

### DIFF
--- a/Sources/TextView/Coordinator.swift
+++ b/Sources/TextView/Coordinator.swift
@@ -94,6 +94,7 @@ extension TextView.Representable.Coordinator {
         textView.isScrollEnabled = representable.isScrollingEnabled
         textView.dataDetectorTypes = representable.autoDetectionTypes
         textView.allowsEditingTextAttributes = representable.allowsRichText
+        textView.keyboardType = representable.keyboardType
 
         switch representable.multilineTextAlignment {
         case .leading:

--- a/Sources/TextView/Modifiers.swift
+++ b/Sources/TextView/Modifiers.swift
@@ -158,4 +158,12 @@ public extension TextView {
         return view
     }
 
+    /// Specifies the keyboard to use
+    /// - Parameter keyboard: The keyboard type
+    func keyboardType(_ keyboard: UIKeyboardType) -> TextView {
+        var view = self
+        view.keyboardType = keyboard
+        return view
+    }
+    
 }

--- a/Sources/TextView/Representable.swift
+++ b/Sources/TextView/Representable.swift
@@ -11,6 +11,7 @@ extension TextView {
         let autocapitalization: UITextAutocapitalizationType
         var multilineTextAlignment: TextAlignment
         let font: UIFont
+        var keyboardType: UIKeyboardType
         let returnKeyType: UIReturnKeyType?
         let clearsOnInsertion: Bool
         let autocorrection: UITextAutocorrectionType

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -20,6 +20,7 @@ public struct TextView: View {
     var autocapitalization: UITextAutocapitalizationType = .sentences
     var multilineTextAlignment: TextAlignment = .leading
     var font: UIFont = .preferredFont(forTextStyle: .body)
+    var keyboardType: UIKeyboardType = .default
     var returnKeyType: UIReturnKeyType?
     var clearsOnInsertion: Bool = false
     var autocorrection: UITextAutocorrectionType = .default
@@ -94,6 +95,7 @@ public struct TextView: View {
             autocapitalization: autocapitalization,
             multilineTextAlignment: multilineTextAlignment,
             font: font,
+            keyboardType: keyboardType,
             returnKeyType: returnKeyType,
             clearsOnInsertion: clearsOnInsertion,
             autocorrection: autocorrection,


### PR DESCRIPTION
Allows to specify other Keyboard Types to the TextView, for example

```swift
TextView($text, $selectedRange)
    .keyboardType(.twitter)
 ```

to display `@` and `#` on the keyboard