### PR TITLE
Added MarkedTextRange Support

### DIFF
--- a/Sources/TextView/Coordinator.swift
+++ b/Sources/TextView/Coordinator.swift
@@ -8,6 +8,7 @@ extension TextView.Representable {
         private var originalText: NSMutableAttributedString = .init()
         private var text: Binding<NSMutableAttributedString>
         private var selectedRange: Binding<NSRange>
+        private var markedTextRange: Binding<UITextRange?>
         private var calculatedHeight: Binding<CGFloat>
       
         var didBecomeFirstResponder = false
@@ -18,6 +19,7 @@ extension TextView.Representable {
 
         init(text: Binding<NSMutableAttributedString>,
              selectedRange: Binding<NSRange>,
+             markedTextRange: Binding<UITextRange?>,
              calculatedHeight: Binding<CGFloat>,
              shouldEditInRange: ((Range<String.Index>, String) -> Bool)?,
              onEditingChanged: (() -> Void)?,
@@ -30,6 +32,7 @@ extension TextView.Representable {
           
             self.text = text
             self.selectedRange = selectedRange
+            self.markedTextRange = markedTextRange
             self.calculatedHeight = calculatedHeight
             self.shouldEditInRange = shouldEditInRange
             self.onEditingChanged = onEditingChanged
@@ -43,6 +46,9 @@ extension TextView.Representable {
           DispatchQueue.main.async {
             if self.selectedRange.wrappedValue != textView.selectedRange {
               self.selectedRange.wrappedValue = textView.selectedRange
+            }
+            if self.markedTextRange.wrappedValue != textView.markedTextRange {
+              self.markedTextRange.wrappedValue = textView.markedTextRange
             }
           }
         }

--- a/Sources/TextView/Representable.swift
+++ b/Sources/TextView/Representable.swift
@@ -5,6 +5,7 @@ extension TextView {
 
         @Binding var text: NSMutableAttributedString
         @Binding var selectedRange: NSRange
+        @Binding var markedTextRange: UITextRange?
         @Binding var calculatedHeight: CGFloat
 
         let foregroundColor: UIColor
@@ -42,6 +43,7 @@ extension TextView {
             Coordinator(
                 text: $text,
                 selectedRange: $selectedRange,
+                markedTextRange: $markedTextRange,
                 calculatedHeight: $calculatedHeight,
                 shouldEditInRange: shouldEditInRange,
                 onEditingChanged: onEditingChanged,

--- a/Sources/TextView/TextView.swift
+++ b/Sources/TextView/TextView.swift
@@ -7,6 +7,7 @@ public struct TextView: View {
 
     @Binding private var text: NSMutableAttributedString
     @Binding private var selectedRange: NSRange
+    @Binding private var markedTextRange: UITextRange?
     @Binding private var isEmpty: Bool
 
     @State private var calculatedHeight: CGFloat = 44
@@ -39,6 +40,7 @@ public struct TextView: View {
     ///   - onCommit: If this is provided, the field will automatically lose focus when the return key is pressed
     public init(_ text: Binding<String>,
                 _ selectedRange: Binding<NSRange>,
+                _ markedTextRange: Binding<UITextRange?>,
          shouldEditInRange: ((Range<String.Index>, String) -> Bool)? = nil,
          onEditingChanged: (() -> Void)? = nil,
          onCommit: (() -> Void)? = nil
@@ -49,6 +51,7 @@ public struct TextView: View {
         )
       
         _selectedRange = selectedRange
+        _markedTextRange = markedTextRange
 
         _isEmpty = Binding(
             get: { text.wrappedValue.isEmpty },
@@ -69,11 +72,13 @@ public struct TextView: View {
     ///   - onCommit: If this is provided, the field will automatically lose focus when the return key is pressed
     public init(_ text: Binding<NSMutableAttributedString>,
                 _ selectedRange: Binding<NSRange>,
+                _ markedTextRange: Binding<UITextRange?>,
                 onEditingChanged: (() -> Void)? = nil,
                 onCommit: (() -> Void)? = nil
     ) {
         _text = text
         _selectedRange = selectedRange
+        _markedTextRange = markedTextRange
         _isEmpty = Binding(
             get: { text.wrappedValue.string.isEmpty },
             set: { _ in }
@@ -89,6 +94,7 @@ public struct TextView: View {
         Representable(
             text: $text,
             selectedRange: $selectedRange,
+            markedTextRange: $markedTextRange,
             calculatedHeight: $calculatedHeight,
             foregroundColor: foregroundColor,
             autocapitalization: autocapitalization,


### PR DESCRIPTION
# Objective

When entering text in iOS, some languages need to take into account a range called 'markedTextRange'.
This `markedTextRange` represents the concept of "pre-finalized text", and speakers of languages that require "conversion" for language input need to consider this "pre-finalized text" state.
https://developer.apple.com/documentation/uikit/uitextinput/1614489-markedtextrange

For example, if a Japanese-speaking user tries to input text in your IceCube application, the following problem will occur if you do not take the markedTextRange into account.

https://user-images.githubusercontent.com/31161372/214290646-62e00e1b-13d6-45d4-bdfc-b5a94ef2e8fc.MP4

This user wants to input the word "あ" and have "words starting with あ" converted before inputting the text, but currently TextView cannot acquire the markedTextRange state, so the text finalization process will be executed.

Originally, the user expected the following state, in which conversion candidates are displayed at the top of the software keyboard.

https://user-images.githubusercontent.com/31161372/214290714-7771f111-6df9-4381-94a6-def4b2461d38.MP4

The actual processing needs to be considered by `IceCube`, but I opened this PR because I need to be able to pass `markedTextRange` as a library.

This is my first PR. Please let me know if I am missing something.

(I'm not native english speaker, so these sentences made by machine translation sorry 🙏 )
