### PR TITLE
Delay update attributedText only if there is no marked text

### DIFF
--- a/Sources/TextView/Coordinator.swift
+++ b/Sources/TextView/Coordinator.swift
@@ -92,7 +92,9 @@ extension TextView.Representable {
 extension TextView.Representable.Coordinator {
 
     func update(representable: TextView.Representable) {
-        textView.attributedText = representable.text
+        if textView.markedTextRange == nil {
+            textView.attributedText = representable.text
+        }
         textView.selectedRange = representable.selectedRange
         textView.font = representable.font
         textView.adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
Avoid interrupting the confirmation of multistage text input.

Currently, the first typing will be interrupted and somehow reset to `""` in Ice Cubes.
I am not sure if this issue will occur in any multistage text input, but I can reproduce it in Japanese and Chinese input.

Original report: https://social.vivaldi.net/@rriver/109784257738294935